### PR TITLE
Added framework for Squish modifier

### DIFF
--- a/source/blender/makesdna/DNA_modifier_types.h
+++ b/source/blender/makesdna/DNA_modifier_types.h
@@ -84,6 +84,7 @@ typedef enum ModifierType {
   eModifierType_MeshToVolume = 58,
   eModifierType_VolumeDisplace = 59,
   eModifierType_VolumeToMesh = 60,
+  eModifierType_Squish = 61,
   NUM_MODIFIER_TYPES,
 } ModifierType;
 
@@ -2380,6 +2381,15 @@ typedef enum VolumeToMeshResolutionMode {
 typedef enum VolumeToMeshFlag {
   VOLUME_TO_MESH_USE_SMOOTH_SHADE = 1 << 0,
 } VolumeToMeshFlag;
+
+/** Squish modifier. */
+typedef struct SquishModifierData {
+  ModifierData modifier;
+
+  /** Factor for squish */
+  float factor;
+  char _pad[4];
+} SquishModifierData;
 
 #ifdef __cplusplus
 }

--- a/source/blender/makesrna/intern/rna_modifier.c
+++ b/source/blender/makesrna/intern/rna_modifier.c
@@ -253,6 +253,11 @@ const EnumPropertyItem rna_enum_object_modifier_type_items[] = {
      ICON_MOD_SMOOTH,
      "Smooth Laplacian",
      "Reduce the noise on a mesh surface with minimal changes to its shape"},
+    {eModifierType_Squish,
+     "SQUISH",
+     ICON_FULLSCREEN_EXIT,
+     "Squish",
+     "Deform the mesh to change its perceived FOV"},
     {eModifierType_SurfaceDeform,
      "SURFACE_DEFORM",
      ICON_MOD_MESHDEFORM,
@@ -7232,6 +7237,28 @@ static void rna_def_modifier_volume_to_mesh(BlenderRNA *brna)
   RNA_define_lib_overridable(false);
 }
 
+static void rna_def_modifier_squish(BlenderRNA *brna)
+{
+  StructRNA *srna;
+  PropertyRNA *prop;
+
+  // Define the RNA and bind it to the SquishModifierData DNA struct
+  srna = RNA_def_struct(brna, "SquishModifier", "Modifier");
+  RNA_def_struct_ui_text(srna, "Squish Modifier", "Squish modifier");
+  RNA_def_struct_sdna(srna, "SquishModifierData");
+  RNA_def_struct_ui_icon(srna, ICON_FULLSCREEN_EXIT);
+
+  RNA_define_lib_overridable(true); // probably
+
+  prop = RNA_def_property(srna, "factor", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_range(prop, -FLT_MAX, FLT_MAX);
+  RNA_def_property_ui_range(prop, -10.0, 10.0, 1.0, 3);
+  RNA_def_property_ui_text(prop, "Factor", "Amount to squish object");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  RNA_define_lib_overridable(false);
+}
+
 void RNA_def_modifier(BlenderRNA *brna)
 {
   StructRNA *srna;
@@ -7383,6 +7410,7 @@ void RNA_def_modifier(BlenderRNA *brna)
   rna_def_modifier_mesh_to_volume(brna);
   rna_def_modifier_volume_displace(brna);
   rna_def_modifier_volume_to_mesh(brna);
+  rna_def_modifier_squish(brna);
 }
 
 #endif

--- a/source/blender/modifiers/CMakeLists.txt
+++ b/source/blender/modifiers/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SRC
   intern/MOD_solidify.c
   intern/MOD_solidify_extrude.c
   intern/MOD_solidify_nonmanifold.c
+  intern/MOD_squish.c
   intern/MOD_subsurf.c
   intern/MOD_surface.c
   intern/MOD_surfacedeform.c

--- a/source/blender/modifiers/MOD_modifiertypes.h
+++ b/source/blender/modifiers/MOD_modifiertypes.h
@@ -75,6 +75,7 @@ extern ModifierTypeInfo modifierType_Nodes;
 extern ModifierTypeInfo modifierType_MeshToVolume;
 extern ModifierTypeInfo modifierType_VolumeDisplace;
 extern ModifierTypeInfo modifierType_VolumeToMesh;
+extern ModifierTypeInfo modifierType_Squish;
 
 /* MOD_util.c */
 

--- a/source/blender/modifiers/intern/MOD_squish.c
+++ b/source/blender/modifiers/intern/MOD_squish.c
@@ -1,0 +1,57 @@
+//
+//  MOD_squish.c
+//  bf_modifiers
+//
+//  Created by claire on 9/16/22.
+//
+
+#include "BLT_translation.h"
+
+#include "DNA_defaults.h"
+#include "DNA_mesh_types.h"
+#include "DNA_meshdata_types.h"
+#include "DNA_object_types.h"
+#include "DNA_screen_types.h"
+
+#include "RNA_access.h"
+#include "RNA_prototypes.h"
+
+#include "BKE_modifier.h"
+
+#include "UI_resources.h"
+
+
+
+ModifierTypeInfo modifierType_Squish = {
+    /* name */ N_("Squish"),
+    /* structName */ "SquishModifierData",
+    /* structSize */ sizeof(SquishModifierData),
+    /* srna */ &RNA_SquishModifier,
+    /* type */ eModifierTypeType_OnlyDeform,
+
+    /* flags */ eModifierTypeFlag_AcceptsMesh,
+    /* icon */ ICON_FULLSCREEN_EXIT,
+
+    /* copyData */ BKE_modifier_copydata_generic,
+
+    /* deformVerts */ NULL,
+    /* deformMatrices */ NULL,
+    /* deformVertsEM */ NULL,
+    /* deformMatricesEM */ NULL,
+    /* modifyMesh */ NULL,
+    /* modifyGeometrySet */ NULL,
+
+    /* initData */ NULL,
+    /* requiredDataMask */ NULL,
+    /* freeData */ NULL,
+    /* isDisabled */ NULL,
+    /* updateDepsgraph */ NULL,
+    /* dependsOnTime */ NULL,
+    /* dependsOnNormals */ NULL,
+    /* foreachIDLink */ NULL,
+    /* foreachTexLink */ NULL,
+    /* freeRuntimeData */ NULL,
+    /* panelRegister */ NULL,
+    /* blendWrite */ NULL,
+    /* blendRead */ NULL,
+};

--- a/source/blender/modifiers/intern/MOD_util.c
+++ b/source/blender/modifiers/intern/MOD_util.c
@@ -333,5 +333,6 @@ void modifier_type_init(ModifierTypeInfo *types[])
   INIT_TYPE(VolumeDisplace);
   INIT_TYPE(VolumeToMesh);
   INIT_TYPE(Nodes);
+  INIT_TYPE(Squish);
 #undef INIT_TYPE
 }


### PR DESCRIPTION
Followed Elie Michel's tutorial
https://blog.exppad.com/article/writing-blender-modifier to create the framework for a squish modifier, which warps the mesh relative to the camera to change the object's perceived FOV (like a dolly zoom, but just for one object)

Currently the modifier exists in data, but doesn't yet have any implemented methods.